### PR TITLE
Update to Jekyll 4.4.1 and replace deprecated sass @import with @use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,11 @@
 source "https://rubygems.org"
 
-gem "jekyll", "3.5.2"
+gem "jekyll", "4.4.1"
 
 gem "jekyll-minifier", "0.1.10"
+
+gem "logger"
+
+gem "base64"
+
+gem "bigdecimal"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,159 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.5)
+    cssminify2 (2.1.0)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    execjs (2.10.0)
+    ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.33.1)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    htmlcompressor (0.4.0)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-minifier (0.1.10)
+      cssminify2 (~> 2.0)
+      htmlcompressor (~> 0.4)
+      jekyll (>= 3.5)
+      json-minify (~> 0.0.3)
+      uglifier (~> 4.1)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.16.0)
+    json-minify (0.0.3)
+      json (> 0)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.3.0)
+    mercenary (0.3.6)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (6.0.2)
+    rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.6.1)
+    safe_yaml (1.0.5)
+    sass-embedded (1.94.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.94.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    uglifier (4.2.1)
+      execjs (>= 0.3.0, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.1)
+
+PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  base64
+  bigdecimal
+  jekyll (= 4.4.1)
+  jekyll-minifier (= 0.1.10)
+  logger
+
+BUNDLED WITH
+   2.7.1

--- a/_includes/experience.html
+++ b/_includes/experience.html
@@ -1,6 +1,6 @@
 {% assign experience = site.data.data.experience %}
 {% if experience %}
-<section class="experiance">
+<section class="experience">
     <h2 class="title">Experience</h2>
     {% for exp in experience %}
         <div class="experience-item">

--- a/_sass/includes/career-profile.scss
+++ b/_sass/includes/career-profile.scss
@@ -1,8 +1,10 @@
+@use "../mixins";
+
 .career-profile {
     .title {
-        @include header;
+        @include mixins.header;
     }
     .details {
-        @include body-text;
+        @include mixins.body-text;
     }
 }

--- a/_sass/includes/contact.scss
+++ b/_sass/includes/contact.scss
@@ -1,7 +1,9 @@
+@use "../mixins";
+
 .contact {
     margin-bottom: 20px;
     .title {
-        @include sub-header;
+        @include mixins.sub-header;
     }
     .contact-item {
         display: flex;
@@ -15,7 +17,7 @@
             text-decoration: none;
             padding-top: 4px;
             padding-left: 4px;
-            @include body-text;
+            @include mixins.body-text;
             &:hover {
                 text-decoration: underline;
             }

--- a/_sass/includes/education.scss
+++ b/_sass/includes/education.scss
@@ -1,19 +1,21 @@
+@use "../mixins";
+
 .education {
     margin-bottom: 20px;
     .title {
-        @include sub-header;
+        @include mixins.sub-header;
     }
     .education-item {
         margin-bottom: 20px;
         .degree {
-            @include body-text;
+            @include mixins.body-text;
             font-weight: bold;
         }
         .university {
-            @include body-text;
+            @include mixins.body-text;
         }
         .time {
-            @include body-text;
+            @include mixins.body-text;
         }
     }
 }

--- a/_sass/includes/experience.scss
+++ b/_sass/includes/experience.scss
@@ -1,13 +1,15 @@
-.experiance {
+@use "../mixins";
+
+.experience {
     .title {
-        @include header;
+        @include mixins.sub-header;
     }
     .experience-item {
         .role {
-            @include sub-header;
+            @include mixins.sub-header;
         }
         .company {
-            @include body-text;
+            @include mixins.body-text;
             font-weight: bold;
             .time {
                 float: right;
@@ -16,10 +18,10 @@
             }
         }
         .details {
-            @include body-text;
+            @include mixins.body-text;
         }
         .technologies {
-            @include body-text;
+            @include mixins.body-text;
         }
     }
 }

--- a/_sass/includes/experience.scss
+++ b/_sass/includes/experience.scss
@@ -2,7 +2,7 @@
 
 .experience {
     .title {
-        @include mixins.sub-header;
+        @include mixins.header;
     }
     .experience-item {
         .role {

--- a/_sass/includes/languages.scss
+++ b/_sass/includes/languages.scss
@@ -1,9 +1,11 @@
+@use "../mixins";
+
 .languages {
     margin-bottom: 20px;
     .title {
-        @include sub-header;
+        @include mixins.sub-header;
     }
     .idiom {
-        @include body-text;
+        @include mixins.body-text;
     }
 }

--- a/_sass/includes/projects.scss
+++ b/_sass/includes/projects.scss
@@ -1,14 +1,16 @@
+@use "../mixins";
+
 .projects {
     .title {
-        @include header;
+        @include mixins.header;
     }
     .project {
         margin-bottom: 20px;
         .project-link {
-            @include body-text;
+            @include mixins.body-text;
         }
         .details {
-            @include body-text;
+            @include mixins.body-text;
         }
     }
 }

--- a/_sass/includes/publications.scss
+++ b/_sass/includes/publications.scss
@@ -1,6 +1,8 @@
+@use "../mixins";
+
 .publications {
     .title {
-        @include header;
+        @include mixins.header;
     }
     .publication-items {
         .publication-item {
@@ -9,14 +11,14 @@
                 a {
                     text-decoration: none;
                     font-weight: bold;
-                    @include body-text; 
+                    @include mixins.body-text; 
                 }
             }
             .authors {
-                @include body-text; 
+                @include mixins.body-text; 
             }
             .conference {
-                @include body-text; 
+                @include mixins.body-text; 
                 color: var(--fg-color-title-sm);
                 font-weight: 100;
             }

--- a/_sass/includes/skills.scss
+++ b/_sass/includes/skills.scss
@@ -1,10 +1,12 @@
+@use "../mixins";
+
 .skills {
     margin-bottom: 20px;
     .title {
         margin-top: 20px;
-        @include sub-header;
+        @include mixins.sub-header;
     }
     .skill {
-        @include body-text;
+        @include mixins.body-text;
     }
 }

--- a/_sass/includes/volunteering.scss
+++ b/_sass/includes/volunteering.scss
@@ -1,14 +1,16 @@
+@use "../mixins";
+
 .volunteering {
     .title {
-        @include header;
+        @include mixins.header;
     }
     .volunteering-item {
         margin-bottom: 20px;
         .role {
-            @include sub-header;
+            @include mixins.sub-header;
         }
         .organization {
-            @include body-text;
+            @include mixins.body-text;
             font-weight: bold;
             .time {
                 float: right;
@@ -17,7 +19,7 @@
             }
         }
         .details {
-            @include body-text;
+            @include mixins.body-text;
         }
     }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1,19 +1,19 @@
 ---
 ---
 
-@import "base";
-@import "print";
-@import "responsive";
-@import "mixins";
-@import "skins/{{ site.theme_skin}}";
+@use "base";
+@use "print";
+@use "responsive";
+@use "mixins";
+@use "skins/{{ site.theme_skin}}";
 
-@import "includes/header";
-@import "includes/career-profile";
-@import "includes/contact";
-@import "includes/languages";
-@import "includes/education";
-@import "includes/skills";
-@import "includes/experience";
-@import "includes/publications";
-@import "includes/projects";
-@import "includes/volunteering";
+@use "includes/header";
+@use "includes/career-profile";
+@use "includes/contact";
+@use "includes/languages";
+@use "includes/education";
+@use "includes/skills";
+@use "includes/experience";
+@use "includes/publications";
+@use "includes/projects";
+@use "includes/volunteering";


### PR DESCRIPTION
In updating the deprecated sass `@import` declaration, namespaces are added to the relevant files within the `_sass/includes/` folder per the `@use` [documentation](https://sass-lang.com/documentation/at-rules/use/).